### PR TITLE
Fix a bunch of links on the persona pages

### DIFF
--- a/data/developers.yaml
+++ b/data/developers.yaml
@@ -5,55 +5,55 @@ milestones:
     actions:
       setup:
         label: Set up your development environment
-        link: "https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#environment-setup"
+        url: "https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#environment-setup"
       learn:
         label: Learn how Ansible works
-        link: "https://docs.ansible.com/ansible/latest/dev_guide/overview_architecture.html"
+        url: "https://docs.ansible.com/ansible/latest/dev_guide/overview_architecture.html"
       code:
         label: Write custom modules or plugins
-        link: "https://docs.ansible.com/ansible/latest/dev_guide/developing_locally.html"
+        url: "https://docs.ansible.com/ansible/latest/dev_guide/developing_locally.html"
   contribute:
     title: Contribute code to a collection
     actions:
       first_contribution:
         label: Make your first contribution
-        link: "https://docs.ansible.com/ansible/latest/community/contributor_path.html#making-your-first-contribution"
+        url: "https://docs.ansible.com/ansible/latest/community/contributor_path.html#making-your-first-contribution"
       collection_contrib_guide:
         label: Explore the Collection contributor guide
-        link: "https://docs.ansible.com/ansible/latest/community/contributions_collections.html"
+        url: "https://docs.ansible.com/ansible/latest/community/contributions_collections.html"
       checklist:
         label: Contribute your module to an existing collection
-        link: "https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_checklist.html"
+        url: "https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_checklist.html"
       lifecycle:
         label: Review the lifecycle of an Ansible module or plugin
-        link: "https://docs.ansible.com/ansible/latest/dev_guide/module_lifecycle.html"
+        url: "https://docs.ansible.com/ansible/latest/dev_guide/module_lifecycle.html"
   test:
     title: Test plugins and modules
     actions:
       learn:
         label: Understand testing in Ansible
-        link: "https://docs.ansible.com/ansible/latest/dev_guide/testing.html#why-test-your-ansible-contributions"
+        url: "https://docs.ansible.com/ansible/latest/dev_guide/testing.html#why-test-your-ansible-contributions"
       run:
         label: Run sanity tests
-        link: "https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html"
+        url: "https://docs.ansible.com/ansible/latest/dev_guide/testing_sanity.html"
       integration:
         label: Write integration tests
-        link: "https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html#testing-integration"
+        url: "https://docs.ansible.com/ansible/latest/dev_guide/testing_integration.html#testing-integration"
       unit:
         label: Write unit tests
-        link: "https://docs.ansible.com/ansible/latest/dev_guide/testing_units.html#testing-units"
+        url: "https://docs.ansible.com/ansible/latest/dev_guide/testing_units.html#testing-units"
   create_collection:
     title: Create new collections
     actions:
       skeleton:
         label: Set things up with the collection skeleton
-        link: "https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_creating.html#creating-collections-skeleton"
+        url: "https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_creating.html#creating-collections-skeleton"
       test:
         label: Test your collection for code quality
-        link: "https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_testing.html"
+        url: "https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_testing.html"
       distribute:
         label: Publish your collection on a distribution server
-        link: "https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_distributing.html#initial-configuration-of-your-distribution-server-or-servers"
+        url: "https://docs.ansible.com/ansible/devel/dev_guide/developing_collections_distributing.html#initial-configuration-of-your-distribution-server-or-servers"
       request_inclusion:
         label: Request a collection be added to the Ansible package
-        link: "https://github.com/ansible-collections/ansible-inclusion"
+        url: "https://github.com/ansible-collections/ansible-inclusion"

--- a/data/maintainers.yaml
+++ b/data/maintainers.yaml
@@ -5,46 +5,46 @@ milestones:
     actions:
       guidelines:
         label: Review community maintainer responsibilities
-        link: "https://docs.ansible.com/ansible/latest/community/maintainers_guidelines.html"
+        url: "https://docs.ansible.com/ansible/latest/community/maintainers_guidelines.html"
       backports:
         label: Backport merged pull requests to stable branches
-        link: "https://docs.ansible.com/ansible/latest/community/maintainers_workflow.html#backporting"
+        url: "https://docs.ansible.com/ansible/latest/community/maintainers_workflow.html#backporting"
       release:
         label: Regularly release stable versions
-        link: "https://docs.ansible.com/ansible/latest/community/collection_contributors/collection_releasing.html#releasing"
+        url: "https://docs.ansible.com/ansible/latest/community/collection_contributors/collection_releasing.html#releasing"
       documentation:
         label: Look after collection documentation
-        link: "https://docs.ansible.com/ansible/latest/community/maintainers_guidelines.html#maintaining-good-collection-documentation"
+        url: "https://docs.ansible.com/ansible/latest/community/maintainers_guidelines.html#maintaining-good-collection-documentation"
   build_community:
     title: Expand community around a collection
     actions:
       grow_community:
         label: Explore ways to grow community
-        link: "https://docs.ansible.com/ansible/latest/community/maintainers_guidelines.html#expanding-the-collection-community"
+        url: "https://docs.ansible.com/ansible/latest/community/maintainers_guidelines.html#expanding-the-collection-community"
       documentation:
         label: Maintain good contributor documentation
-        link: "https://docs.ansible.com/ansible/latest/community/maintainers_guidelines.html#maintaining-good-collection-documentation"
+        url: "https://docs.ansible.com/ansible/latest/community/maintainers_guidelines.html#maintaining-good-collection-documentation"
       contributor_paths:
         label: Understand Ansible contributor paths
-        link: "https://docs.ansible.com/ansible/latest/community/contributor_path.html"
+        url: "https://docs.ansible.com/ansible/latest/community/contributor_path.html"
   collection_inclusion:
     title: Get collections included in the Ansible package
     actions:
       process:
         label: Understand the inclusion process
-        link: "https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html#collection-inclusion-requests-workflow"
+        url: "https://docs.ansible.com/ansible/devel/community/steering/community_steering_committee.html#collection-inclusion-requests-workflow"
       review:
         label: Review other inclusion requests
-        link: "https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md#review-process"
+        url: "https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md#review-process"
       submit:
         label: Submit your collection for inclusion
-        link: "https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md#submission-process"
+        url: "https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md#submission-process"
   participate:
     title: Participate in cross-project governance
     actions:
       community_topics:
         label: Discuss and vote on community topics
-        link: "https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-topics"
+        url: "https://docs.ansible.com/ansible/devel/community/communication.html#ansible-community-topics"
       join:
         label: Join the Ansible community steering committee
-        link: "https://docs.ansible.com/ansible/latest/community/contributor_path.html#become-a-steering-committee-member"
+        url: "https://docs.ansible.com/ansible/latest/community/contributor_path.html#become-a-steering-committee-member"

--- a/templates/developers.tmpl
+++ b/templates/developers.tmpl
@@ -31,7 +31,7 @@
              aria-label="{{ homepage.labels.button_group }}">
           {%- for action_key, action_value in value.actions.items() %}
             <div class="doc-link-row doc-link">
-              <i class="fas fa-book"></i><a class="btn" href="{{ action_value.link }}" role="button">{{ action_value.label }}</a>
+              <i class="fas fa-book"></i><a class="btn" href="{{ action_value.url }}" role="button">{{ action_value.label }}</a>
             </div>
           {%- endfor %}
         </div>

--- a/templates/developers.tmpl
+++ b/templates/developers.tmpl
@@ -13,7 +13,7 @@
         <h2>{{ quicklinks.labels.developers }}</h2>
         {%- for key, item in quicklinks.developers.items() %}
           <div class="top-link">
-            <i class="fas fa-bookmark"></i><a class="btn" href="{{ item.link }}" role="button">{{
+            <i class="fas fa-bookmark"></i><a class="btn" href="{{ item.url }}" role="button">{{
               item.label
             }}</a>
           </div>

--- a/templates/maintainers.tmpl
+++ b/templates/maintainers.tmpl
@@ -31,7 +31,7 @@
              aria-label="{{ homepage.labels.button_group }}">
           {%- for action_key, action_value in value.actions.items() %}
             <div class="doc-link-row doc-link">
-              <i class="fas fa-book"></i><a class="btn" href="{{ action_value.link }}" role="button">{{ action_value.label }}</a>
+              <i class="fas fa-book"></i><a class="btn" href="{{ action_value.url }}" role="button">{{ action_value.label }}</a>
             </div>
           {%- endfor %}
         </div>

--- a/templates/maintainers.tmpl
+++ b/templates/maintainers.tmpl
@@ -13,7 +13,7 @@
         <h2>{{ quicklinks.labels.maintainers }}</h2>
         {%- for key, item in quicklinks.maintainers.items() %}
           <div class="top-link">
-            <i class="fas fa-bookmark"></i><a class="btn" href="{{ item.link }}" role="button">{{
+            <i class="fas fa-bookmark"></i><a class="btn" href="{{ item.url }}" role="button">{{
               item.label
             }}</a>
           </div>

--- a/templates/users.tmpl
+++ b/templates/users.tmpl
@@ -31,7 +31,7 @@
              aria-label="{{ homepage.labels.button_group }}">
           {%- for action_key, action_value in value.actions.items() %}
             <div class="doc-link-row doc-link">
-              <i class="fas fa-book"></i><a class="btn" href="{{ action_value.link }}" role="button">{{
+              <i class="fas fa-book"></i><a class="btn" href="{{ action_value.url }}" role="button">{{
                 action_value.label
               }}</a>
             </div>

--- a/templates/users.tmpl
+++ b/templates/users.tmpl
@@ -13,7 +13,7 @@
         <h2>{{ quicklinks.labels.users }}</h2>
         {%- for key, item in quicklinks.users.items() %}
           <div class="top-link">
-            <i class="fas fa-bookmark"></i><a class="btn" href="{{ item.link }}" role="button">{{
+            <i class="fas fa-bookmark"></i><a class="btn" href="{{ item.url }}" role="button">{{
               item.label
             }}</a>
           </div>


### PR DESCRIPTION
The users, developers, and maintainers pages have incorrect keys in either the template or the yaml file. The keys were not the same in the `ansible/docsite` repo and I didn't fix the inconsistency when I ported over that content.

The result is that the link text on the page looks fine but the link itself is broken. This PR fixes that and makes the names of keys consistent with the rest of the templates.